### PR TITLE
Clarify DAE Model Structure

### DIFF
--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -160,7 +160,7 @@ The partial derivative API functions <<fmi3GetDirectionalDerivative>> and <<fmi3
 * When the unknown is a <<Residual>> (i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
 
 ==== Hello World DAE Example
-Below outlines how to map the different forms of the Hello World DAE Example to the manifest file detailed here. 
+Below outlines how to map the different forms of the Hello World DAE Example to the manifest file detailed here.
 
 ===== Hello World DAE - Fully-Implicit DAE
 
@@ -240,7 +240,7 @@ In this case `x_2` and `x_3` do not appear differentiated in any equations, henc
   </Residual>
 </ModelStructure>
 ```
-NOTE: The derivatives of `x_1`, `x_2`, and `x_3` (`\dot{x_1}`, `\dot{x_2}`, `\dot{x_3}`) are still noted with the `derivative` attribute under the `ModelVariables` element, which gives the importer all the information they need to solve the equations. 
+NOTE: The derivatives of `x_1`, `x_2`, and `x_3` (`\dot{x_1}`, `\dot{x_2}`, `\dot{x_3}`) are still noted with the `derivative` attribute under the `ModelVariables` element, which gives the importer all the information they need to solve the equations.
 
 ===== Hello World DAE - Semi-Explicit DAE
 
@@ -470,4 +470,3 @@ latexmath:[\dot{r}_3 = \frac{dx_1}{dt} - \frac{dx_2}{dt} = 0]
 ```
 
 The API for partial derivative, `GetDirectionalDerivative` and/or `GetAdjointDerivative` could be used with this structure to apply the dummy derivatives algorithm, or the index 2 constraint can serve as a projection constraint when integrating the index 1 formulation.
-

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -15,12 +15,12 @@ Two additional elements - `<AlgebraicVariables>` and `<ModelStructure>` - are in
 |Description
 
 |<<AlgebraicVariables>>
-|List of all <<algebraic,algebraic variables>> exposed for the DAE formulation.
+|List of all <<AlgebraicVariable>> exposed for the DAE formulation.
 
 |<<ModelStructure>>
 |Defines the structure of the DAE formulation for the model.
-Especially, the ordered lists of <<output,`outputs`>>, continuous-time <<state,states>>, and the initial unknowns (the unknowns during <<InitializationMode>>) are *re*-defined and overwrite the corresponding `<ModelStructure>` present in the `modelDescription.xml`, with the addition of the  <<residuals, `residuals`>> element.
-The <<algebraic,algebraic variables>> can now also be included as dependencies.
+Especially, the ordered lists of https://fmi-standard.org/docs/3.0.2/#output[outputs], continuous-time https://fmi-standard.org/docs/3.0.2/#state[state], and the initial unknowns (the unknowns during https://fmi-standard.org/docs/3.0.2/#InitializationMode[InitializationMode]) are *re*-defined and overwrite the corresponding `<ModelStructure>` present in the `modelDescription.xml`, with the addition of the  <<Residual, `residuals`>> element.
+The <<AlgebraicVariables,algebraic variables>> can now also be included as dependencies.
 
 |<<Annotations>>
 |Optional annotations for the top-level element.
@@ -55,20 +55,22 @@ The XML attributes of `<fmiLayeredStandardManifest>` are:
 |====
 
 === Algebraic variables [[AlgebraicVariables, `<AlgebraicVariables>`]]
+
 The element `<AlgebraicVariables>` defines the list of the algebraic variables.
 
 .AlgebraicVariables elements.
-[[table-algebraicvariables-details]]
+[[table-algebraic-variables-details]]
 [cols="1,5a", options="header"]
 |====
 |Element
 |Description
 
 |`AlgebraicVariable`
-|The list of all algebraic variables present in the `ModelVariables` element of the modelDescription.xml.
+|The list of all <<AlgebraicVariable>> present in the `ModelVariables` element of the modelDescription.xml.
 |====
 
-Each `<<AlgebraicVariable>>` has only one attribute defining the value reference.
+[[AlgebraicVariable, `<AlgebraicVariable>`]]
+Each <<AlgebraicVariable>> has only one attribute defining the value reference.
 
 .Attributes to <<AlgebraicVariable>> element.
 [[table-alg-details]]
@@ -84,11 +86,13 @@ Each `<<AlgebraicVariable>>` has only one attribute defining the value reference
 === Model Structure [[ModelStructure,`<ModelStructure>`]]
 
 The structure of the model for the DAE-formulation is defined in element `<ModelStructure>`.
-It defines the <<model-dependencies,dependencies>> between variables. The `<ModelStructure>` element is extended with an additional element - <<Residual>> - and the optional dependencies can now include algebraic variables.
+It defines the <<model-dependencies,dependencies>> between variables.
+The `<ModelStructure>` element is extended with an additional element - <<Residual>> - and the optional dependencies can now include algebraic variables.
 
 An FMU that follows this layered standard must expose all residuals with the <<Residual>>.
 
-NOTE: The `<ModelStructure>` defined here extends the one from the core FMI standard. All elements defined there (`Output`, `ContinuousStateDerivative`, `ClockedState`, `InitialUnknown`, `EventIndicator`) retain their existing semantics, with the addition that each element's `dependencies` attribute may now also reference algebraic variables (variables listed in the `<<AlgebraicVariables>>` element).
+NOTE: The `<ModelStructure>` defined here extends the one from the core FMI standard.
+All elements defined there (`Output`, `ContinuousStateDerivative`, `ClockedState`, `InitialUnknown`, `EventIndicator`) retain their existing semantics, with the addition that each element's `dependencies` attribute may now also reference algebraic variables (variables listed in the `<<AlgebraicVariables>>` element).
 
 The `<ModelStructure>` element is extended with one additional element, <<Residual>>, described below.
 
@@ -101,7 +105,12 @@ The `<ModelStructure>` element is extended with one additional element, <<Residu
 
 |`Residual`
 |[[Residual,`<Residual>`]]
-Ordered list of residual equations (constraints). Each `<Residual>` contains one or more `<<Formulation>>` child elements. When a single `<Formulation>` is present, it defines the residual equation directly. When multiple `<Formulation>` elements are present within the same `<Residual>`, they represent the same constraint differentiated to successive orders. This grouping tells the importer that the equations are structurally related, which can e.g. be used to perform index reduction with dummy derivatives or projection methods. Note that each formulation inside one residual element must reference unique variables in the FMU.
+Ordered list of residual equations (constraints).
+Each `<Residual>` contains one or more `<<Formulation>>` child elements.
+When a single `<Formulation>` is present, it defines the residual equation directly.
+When multiple `<Formulation>` elements are present within the same `<Residual>`, they represent the same constraint differentiated to successive orders.
+This grouping tells the importer that the equations are structurally related, which can e.g. be used to perform index reduction with dummy derivatives or projection methods.
+Note that each formulation inside one residual element must reference unique variables in the FMU.
 
 The functional dependency is defined as: +
 latexmath:[{0 := \mathbf{f}_{\mathit{res}}(\mathbf{x}_c, \mathbf{z}_c, \mathbf{u}_c, t, \mathbf{p})}]
@@ -126,40 +135,47 @@ Each `<<Formulation>>` element within a `<<Residual>>` has the following attribu
 Optional attribute indicating the DAE index of the original constraint, i.e., how many times this particular equation must be differentiated in order to solve for a particular derivative.
 
 |`dependencies`
-|Optional attribute defining the algebraic dependencies as a list of value references of the knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] that this formulation directly depends on.
+|[[model-dependencies]]
+Optional attribute defining the algebraic dependencies as a list of value references of the knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] that this formulation directly depends on.
 
-Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<ContinuousTimeMode>> (ME) for `<<Formulation>>` elements are: +
+Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in https://fmi-standard.org/docs/3.0.2/#table-math-model-exchange[ContinuousTimeMode] (ME) for `<<Formulation>>` elements are: +
 
-* inputs (variables with <<causality>> = <<input>>),
+* inputs (variables with https://fmi-standard.org/docs/3.0.2/#causality[causality] = https://fmi-standard.org/docs/3.0.2/#input[input]),
 
 * continuous states,
 
 * continuous state derivatives,
 
-* parameters (variables with <<causality>> = <<parameter>>),
+* parameters (variables with https://fmi-standard.org/docs/3.0.2/#causality[causality] = https://fmi-standard.org/docs/3.0.2/#parameter[parameter]),
 
 * algebraic variables (variables listed in the `<<AlgebraicVariables>>` element),
 
-* <<independent>> variable (usually time; <<causality>> = <<independent>>).
+* https://fmi-standard.org/docs/3.0.2/#independent[indipendent] variable (usually time; https://fmi-standard.org/docs/3.0.2/#causality[causality] = https://fmi-standard.org/docs/3.0.2/#independent[indipendent]).
 
 If `dependencies` is not present, it must be assumed that the formulation depends on all knowns.
 If `dependencies` is present as an empty list, the formulation depends on none of the knowns.
 Otherwise the formulation depends on the knowns defined by the given value references.
 
 |`dependenciesKind`
-|See the description of <<dependenciesKind>> in <<table-output-der-initialUnknown-details>> of the core FMI standard. TODO: Extend to help importer?
+|See the description of https://fmi-standard.org/docs/3.0.2/#dependenciesKind[`dependenciesKind`] in the core FMI standard.
+TODO: Extend to help importer?
 |====
+
+=== Annotations
+
+NOTE: TODO
 
 ---
 
 === Getting Partial Derivatives
 
-The partial derivative API functions <<fmi3GetDirectionalDerivative>> and <<fmi3GetAdjointDerivative>> are used as defined in the core FMI standard, with the following extensions for DAE FMUs:
+The partial derivative API functions https://fmi-standard.org/docs/3.0.2/#fmi3GetDirectionalDerivative[fmi3GetDirectionalDerivative] and https://fmi-standard.org/docs/3.0.2/#fmi3GetAdjointDerivative[fmi3GetAdjointDerivative] are used as defined in the core FMI standard, with the following extensions for DAE FMUs:
 
 * Algebraic variables (variables listed in `<<AlgebraicVariables>>`) may appear as knowns for any unknown.
 * When the unknown is a <<Residual>> (i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
 
 ==== Hello World DAE Example
+
 Below outlines how to map the different forms of the Hello World DAE Example to the manifest file detailed here.
 
 ===== Hello World DAE - Fully-Implicit DAE
@@ -212,7 +228,8 @@ Assume the FMU has these variables:
 |latexmath:[F_3] | 10
 |====
 
-In this case `x_2` and `x_3` do not appear differentiated in any equations, hence they are classified as algebraic (element of `<<AlgebraicVariables>>`). An example of the `<<AlgebraicVariables>>` and `<<ModelStructure>>` elements would be:
+In this case `x_2` and `x_3` do not appear differentiated in any equations, hence they are classified as algebraic (element of `<<AlgebraicVariables>>`).
+An example of the `<<AlgebraicVariables>>` and `<<ModelStructure>>` elements would be:
 
 ```xml
 <AlgebraicVariables>
@@ -288,7 +305,8 @@ Assume the FMU has the following variables:
 |latexmath:[g_2] | 7
 |====
 
-This case contains the same algebraic variables. However this time the the derivative of `x` is given in explicit form in the `ModelStructure`:
+This case contains the same algebraic variables.
+However this time the the derivative of `x` is given in explicit form in the `ModelStructure`:
 
 ```xml
 <AlgebraicVariables>
@@ -297,10 +315,10 @@ This case contains the same algebraic variables. However this time the the deriv
 </AlgebraicVariables>
 
 <ModelStructure>
-  <ContinuousStateDerivative <!-- dot(x) = y1 -->
+  <ContinuousStateDerivative
     valueReference="5"
     dependencies="3"
-    dependenciesKind="fixed"/>
+    dependenciesKind="fixed"/> <!-- dot(x) = y1 -->
   <Residual> <!-- g1: y1 + 2*y2 - x = 0 -->
     <Formulation
       valueReference="6"
@@ -386,7 +404,10 @@ Assume it is exported as a DAE FMU with the following variables:
 |latexmath:[\frac{dr_3}{dt}] | 9
 |====
 
-**Case 1:** No structural analysis. The importer is responsible to figure out how to solve the system:
+**Case 1:**
+No structural analysis.
+The importer is responsible to figure out how to solve the system:
+
 ```xml
 <ModelStructure>
   <Residual> <!-- r1 -->
@@ -410,7 +431,10 @@ Assume it is exported as a DAE FMU with the following variables:
 </ModelStructure>
 ```
 
-**Case 2:** The FMU additionally indicates that latexmath:[r_3] is a constraint of index 2, i.e., it must be differentiated twice to obtain an index 1 system. This gives the importer structural information to know to apply a solver able to handle index 2 problems:
+**Case 2:**
+The FMU additionally indicates that latexmath:[r_3] is a constraint of index 2, i.e., it must be differentiated twice to obtain an index 1 system.
+This gives the importer structural information to know to apply a solver able to handle index 2 problems:
+
 ```xml
 <ModelStructure>
   <Residual> <!-- r1 -->
@@ -435,7 +459,9 @@ Assume it is exported as a DAE FMU with the following variables:
 </ModelStructure>
 ```
 
-**Case 3:** The FMU exposes both latexmath:[r_3] and its time derivative latexmath:[\dot{r}_3] grouped within the same `<Residual>`, which indicates that these are the original constraint and its differentiated form. The importer can use this grouping to apply the dummy derivatives algorithm or use latexmath:[r_3] as a drift-correction projection when integrating the index 1 formulation:
+**Case 3:**
+The FMU exposes both latexmath:[r_3] and its time derivative latexmath:[\dot{r}_3] grouped within the same `<Residual>`, which indicates that these are the original constraint and its differentiated form.
+The importer can use this grouping to apply the dummy derivatives algorithm or use latexmath:[r_3] as a drift-correction projection when integrating the index 1 formulation:
 
 latexmath:[r_3 = x_1 - x_2 = 0]
 
@@ -455,16 +481,16 @@ latexmath:[\dot{r}_3 = \frac{dx_1}{dt} - \frac{dx_2}{dt} = 0]
       dependenciesKind="dependent dependent"/>
   </Residual>
   <Residual> <!-- r3 and its derivative, grouped as related formulations -->
-    <Formulation <!-- r3 -->
+    <Formulation
       index="2"
       valueReference="8"
       dependencies="1 2"
-      dependenciesKind="dependent dependent"/>
-    <Formulation <!-- der(r3) -->
+      dependenciesKind="dependent dependent"/> <!-- r3 -->
+    <Formulation
       index="1"
       valueReference="9"
       dependencies="4 5"
-      dependenciesKind="dependent dependent"/>
+      dependenciesKind="dependent dependent"/> <!-- der(r3) -->
   </Residual>
 </ModelStructure>
 ```

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -5,7 +5,7 @@ This layered standard requires the use of a layered standard manifest file and i
 
 [Add figure here] shows the root element `fmiLayeredStandardManifest`.
 
-Two additional elements - `<AlgebraicVariables>` and `<ModelStructure>` - are included in the layered standard manifest file to describe the DAE formulation.
+Two additional elements - <<AlgebraicVariables>> and <<ModelStructure>> - are included in the layered standard manifest file to describe the DAE formulation.
 
 .`fmiModelDescription` element details.
 [[table-schema-fmiModelDescription]]
@@ -15,11 +15,11 @@ Two additional elements - `<AlgebraicVariables>` and `<ModelStructure>` - are in
 |Description
 
 |<<AlgebraicVariables>>
-|List of all <<AlgebraicVariable>> exposed for the DAE formulation.
+|List of all <<AlgebraicVariable, algebraic variables>> exposed for the DAE formulation.
 
 |<<ModelStructure>>
 |Defines the structure of the DAE formulation for the model.
-Especially, the ordered lists of https://fmi-standard.org/docs/3.0.2/#output[outputs], continuous-time https://fmi-standard.org/docs/3.0.2/#state[state], and the initial unknowns (the unknowns during https://fmi-standard.org/docs/3.0.2/#InitializationMode[InitializationMode]) are *re*-defined and overwrite the corresponding `<ModelStructure>` present in the `modelDescription.xml`, with the addition of the  <<Residual, `residuals`>> element.
+Especially, the ordered lists of https://fmi-standard.org/docs/3.0.2/#output[outputs], continuous-time https://fmi-standard.org/docs/3.0.2/#state[state], and the initial unknowns (the unknowns during https://fmi-standard.org/docs/3.0.2/#InitializationMode[InitializationMode]) are *re*-defined and overwrite the corresponding https://fmi-standard.org/docs/3.0.2/#ModelStructure[ModelStructure] present in the `modelDescription.xml`, with the addition of the  <<Residual, residuals>> element.
 The <<AlgebraicVariables,algebraic variables>> can now also be included as dependencies.
 
 |<<Annotations>>
@@ -56,7 +56,7 @@ The XML attributes of `<fmiLayeredStandardManifest>` are:
 
 === Algebraic variables [[AlgebraicVariables, `<AlgebraicVariables>`]]
 
-The element `<AlgebraicVariables>` defines the list of the algebraic variables.
+The element <<AlgebraicVariables>> defines the list of the algebraic variables.
 
 .AlgebraicVariables elements.
 [[table-algebraic-variables-details]]
@@ -66,7 +66,7 @@ The element `<AlgebraicVariables>` defines the list of the algebraic variables.
 |Description
 
 |`AlgebraicVariable`
-|The list of all <<AlgebraicVariable>> present in the `ModelVariables` element of the modelDescription.xml.
+|An <<AlgebraicVariable>> present in the `ModelVariables` element of the modelDescription.xml.
 |====
 
 [[AlgebraicVariable, `<AlgebraicVariable>`]]
@@ -85,16 +85,16 @@ Each <<AlgebraicVariable>> has only one attribute defining the value reference.
 
 === Model Structure [[ModelStructure,`<ModelStructure>`]]
 
-The structure of the model for the DAE-formulation is defined in element `<ModelStructure>`.
+The structure of the model for the DAE-formulation is defined in element <<ModelStructure>>.
 It defines the <<model-dependencies,dependencies>> between variables.
-The `<ModelStructure>` element is extended with an additional element - <<Residual>> - and the optional dependencies can now include algebraic variables.
+The <<ModelStructure>> element is extended with an additional element - <<Residual>> - and the optional dependencies can now include algebraic variables.
 
 An FMU that follows this layered standard must expose all residuals with the <<Residual>>.
 
-NOTE: The `<ModelStructure>` defined here extends the one from the core FMI standard.
-All elements defined there (`Output`, `ContinuousStateDerivative`, `ClockedState`, `InitialUnknown`, `EventIndicator`) retain their existing semantics, with the addition that each element's `dependencies` attribute may now also reference algebraic variables (variables listed in the `<<AlgebraicVariables>>` element).
+NOTE: The <<ModelStructure>> defined here extends the one from the core FMI standard.
+All elements defined there (`Output`, `ContinuousStateDerivative`, `ClockedState`, `InitialUnknown`, `EventIndicator`) retain their existing semantics, with the addition that each element's `dependencies` attribute may now also reference <<AlgebraicVariable, algebraic variables>>.
 
-The `<ModelStructure>` element is extended with one additional element, <<Residual>>, described below.
+The <<ModelStructure>> element is extended with one additional element, <<Residual>>, described below.
 
 .Additional ModelStructure element.
 [#table-model-structure-dae-element]
@@ -150,7 +150,7 @@ Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in https://fmi-standard.org/doc
 
 * algebraic variables (variables listed in the `<<AlgebraicVariables>>` element),
 
-* https://fmi-standard.org/docs/3.0.2/#independent[indipendent] variable (usually time; https://fmi-standard.org/docs/3.0.2/#causality[causality] = https://fmi-standard.org/docs/3.0.2/#independent[indipendent]).
+* https://fmi-standard.org/docs/3.0.2/#independent[independent] variable (usually time; https://fmi-standard.org/docs/3.0.2/#causality[causality] = https://fmi-standard.org/docs/3.0.2/#independent[independent]).
 
 If `dependencies` is not present, it must be assumed that the formulation depends on all knowns.
 If `dependencies` is present as an empty list, the formulation depends on none of the knowns.
@@ -167,12 +167,12 @@ NOTE: TODO
 
 ---
 
-=== Getting Partial Derivatives
+==== Getting Partial Derivatives
 
 The partial derivative API functions https://fmi-standard.org/docs/3.0.2/#fmi3GetDirectionalDerivative[fmi3GetDirectionalDerivative] and https://fmi-standard.org/docs/3.0.2/#fmi3GetAdjointDerivative[fmi3GetAdjointDerivative] are used as defined in the core FMI standard, with the following extensions for DAE FMUs:
 
 * Algebraic variables (variables listed in `<<AlgebraicVariables>>`) may appear as knowns for any unknown.
-* When the unknown is a <<Residual>> (i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
+* When the unknown is a <<Formulation>> in a <<Residual>>(i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
 
 ==== Hello World DAE Example
 

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -20,7 +20,7 @@ Two additional elements - `<AlgebraicVariables>` and `<ModelStructure>` - are in
 |<<ModelStructure>>
 |Defines the structure of the DAE formulation for the model.
 Especially, the ordered lists of <<output,`outputs`>>, continuous-time <<state,states>>, and the initial unknowns (the unknowns during <<InitializationMode>>) are *re*-defined and overwrite the corresponding `<ModelStructure>` present in the `modelDescription.xml`, with the addition of the  <<residuals, `residuals`>> element.
-Furthermore, the dependency of the unknowns from the knowns (as described in <<model-dependencies>>) can be optionally defined for <<output,`outputs`>>, continuous-time <<state,states>> and initial unknowns. The <<algebraic,algebraic variables>> can now also be included as dependencies.
+The <<algebraic,algebraic variables>> can now also be included as dependencies.
 
 |<<Annotations>>
 |Optional annotations for the top-level element.
@@ -88,128 +88,26 @@ It defines the <<model-dependencies,dependencies>> between variables. The `<Mode
 
 An FMU that follows this layered standard must expose all residuals with the <<Residual>>.
 
-It should be noted that the ModelStructure below is not a straight extension of the ModelStructure from the core standard, since it e.g. does not specify how the elements `ClockedState` or `EventIndicator` are affected by the DAE-formulation. That is also why some elements in <<table-model-structure-elements>> are defined in a similar way to the core standard, with the exception that references to concepts in co-simulation, clocks, and events are excluded. Moreover, notes and examples that are already present in the core standard are omitted here.
+NOTE: The `<ModelStructure>` defined here extends the one from the core FMI standard. All elements defined there (`Output`, `ContinuousStateDerivative`, `ClockedState`, `InitialUnknown`, `EventIndicator`) retain their existing semantics, with the addition that each element's `dependencies` attribute may now also reference algebraic variables (variables listed in the `<<AlgebraicVariables>>` element).
 
-Similar to the `ModelStructure` from the core FMI-standard, the optional part of the model structure defines in which way <<derivative,`derivatives`>>, <<output,`outputs`>>, and initial unknowns depend on <<input,`inputs`>> and/or <<parameter,`parameters`>>, and continuous-time <<state,states>>. Therefore the concepts from Model Exchange in the core-standard that are applicable to the DAE-formulation are repeated. The unknowns are extended with the <<Residual>> element, and each unknown can now also depend on <<AlgebraicVariables>>.
+The `<ModelStructure>` element is extended with one additional element, <<Residual>>, described below.
 
-.ModelStructure elements.
-[#table-model-structure-elements]
+.Additional ModelStructure element.
+[#table-model-structure-dae-element]
 [cols="1,5a",options="header"]
 |====
 |Element
 |Description
 
-|`Output`
-|[[Output,`<Output>`]]
-Ordered list of all outputs, in other words, a list of value references where every corresponding variable must have <<causality>> = <<output>> (and every variable with <<causality>> = <<output>> must be listed here).
-Attribute <<dependencies>> defines the dependencies of the <<output,`outputs`>> from the knowns after the <<InitializationMode>>.
-The functional dependency is defined as: +
-latexmath:[{(\mathbf{y}_c, \mathbf{y}_d) := \mathbf{f}_{\mathit{output}}(\mathbf{x}_c, \mathbf{z}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p})}]
-
-|`ContinuousStateDerivative`
-|[[ContinuousStateDerivative,`<ContinuousStateDerivative>`]]
-Ordered list of value references of all derivatives of continuous <<state,states>>.
-The order defined by this list defines the order of the elements for <<fmi3GetContinuousStates>>, <<fmi3SetContinuousStates>>, and <<fmi3GetContinuousStateDerivatives>>.
-
-The corresponding continuous-time <<state,states>> are defined by attribute <<derivative>> of the corresponding variable state-derivative element.
-
-The functional dependency is defined as: +
-latexmath:[{\dot{\mathbf{x}}_c := \mathbf{f}_{\mathit{der}}(\mathbf{x}_c, \mathbf{z}_c, \mathbf{u}_c, \mathbf{u}_d, t, \mathbf{p})}]
-
 |`Residual`
 |[[Residual,`<Residual>`]]
-Ordered list of residual equations (constraints). Each `<Residual>` contains one or more `<<Formulation>>` child elements. When a single `<Formulation>` is present, it defines the residual equation directly. When multiple `<Formulation>` elements are present within the same `<Residual>`, they represent the same constraint differentiated to successive orders. This grouping tells the the importer that the equations are structurally related, which can e.g. be used to perform index reduction with dummy derivatives or projection methods. Note that each formulation inside one residual element must be unique variables in the FMU.
+Ordered list of residual equations (constraints). Each `<Residual>` contains one or more `<<Formulation>>` child elements. When a single `<Formulation>` is present, it defines the residual equation directly. When multiple `<Formulation>` elements are present within the same `<Residual>`, they represent the same constraint differentiated to successive orders. This grouping tells the importer that the equations are structurally related, which can e.g. be used to perform index reduction with dummy derivatives or projection methods. Note that each formulation inside one residual element must reference unique variables in the FMU.
 
 The functional dependency is defined as: +
 latexmath:[{0 := \mathbf{f}_{\mathit{res}}(\mathbf{x}_c, \mathbf{z}_c, \mathbf{u}_c, t, \mathbf{p})}]
-
-|`InitialUnknown`
-a|
-[[InitialUnknown,`<InitialUnknown>`]]
-Ordered list of all exposed unknowns in <<InitializationMode>>.
-This list consists of all variables which:
-
-* are not <<clocked-variable,clocked variables>> and have <<causality>> = <<output>> (with <<initial>> = <<approx>> or <<calculated>>), or
-* have <<causality>> = <<calculatedParameter>>, or
-* are continuous-time <<state,states>> or state derivatives (defined with elements <<ContinuousStateDerivative>>) with <<initial>> = <<approx>> or <<calculated>>, or
-* are <<algebraic-variable,algebraic variables>> that the FMU wishes to initialize in initialization mode.
-
-The resulting list is not allowed to have duplicates (for example, if a <<state>> is also an <<output>>, it is included only once in the list). +
-Attribute <<dependencies>> defines the dependencies of the unknowns from the knowns in <<InitializationMode>>.
-The functional dependency is defined as:
-
-latexmath:[{\mathbf{v}_{\mathit{initialUnknowns}} := \mathbf{f}_{\mathit{init}}(\mathbf{u}_c, \mathbf{u}_d, t_{\mathit{start}}, \mathbf{v}_{\mathit{initial=exact}})}]
-
-Since, <<output,`outputs`>>, continuous-time <<state,states>> and state derivatives are either present as knowns (if <<initial>> = <<exact>>) or as unknowns (if <<initial>> = <<approx>> or <<calculated>>), they can be inquired with <<get-and-set-variable-values,`fmi3Get{VariableType}`>> in <<InitializationMode>>.
 |====
 
-Elements <<Output>>, <<ContinuousStateDerivative>>, and <<InitialUnknown>> have (partially) the following attributes. The `<<Residual>>` element differs in that its attributes are carried by its `<<Formulation>>` child elements, as described in <<table-formulation-details>>.
-
-.<<Output>>, <<ContinuousStateDerivative>>, and <<InitialUnknown>> common attributes details.
-[[table-output-der-initialUnknown-details]]
-[cols="1,5a", options="header"]
-|====
-|Attribute
-|Description
-
-|`valueReference`
-|The value reference of the unknown latexmath:[{v_{\mathit{unknown}}}].
-
-|`dependencies`
-|
-[[dependencies,`dependencies`]]
-Optional attribute defining the algebraic dependencies as list of value references of the unknown latexmath:[{\mathbf{v}_{\mathit{unknown}}}] directly with respect to latexmath:[{\mathbf{v}_{\mathit{known}}}].
-For a real valued unknown and a real valued known, if the known is not listed among the dependencies then the partial derivative of the unknown with respect to that known is identically zero.
-If dependencies is not present, it must be assumed that the unknown depends on all knowns.
-If dependencies is present as empty list, the unknown depends on none of the knowns.
-
-Otherwise the unknown depends on the knowns defined by the given value references.
-
-Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<ContinuousTimeMode>> (ME) for <<Output>> and <<ContinuousStateDerivative>> elements are: +
-
-* inputs (variables with <<causality>> = <<input>>),
-
-* continuous states,
-
-* parameters (variables with <<causality>> = <<parameter>>),
-
-* algebraic variables (variables listed in the `<<AlgebraicVariables>>` element)
-
-* <<independent>> variable (usually time; <<causality>> = <<independent>>).
-
-Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<InitializationMode>> (for elements <<InitialUnknown>>) are:
-
-* inputs (variables with <<causality>> = <<input>>),
-
-* variables with <<initial>> = <<exact>>,
-
-* algebraic variables (variables listed in the `<<AlgebraicVariables>>` element)
-
-* <<independent>> variable (usually time; <<causality>> = <<independent>>).
-
-|`dependenciesKind`
-|
-[[dependenciesKind, `dependenciesKind`]]
-If <<dependenciesKind>> is present, <<dependencies>> must be present and must have the same number of list elements.
-If <<dependenciesKind>> is not present, it must be assumed that the unknown latexmath:[{\mathbf{v}_{\mathit{unknown}}}] depends on the knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] without a particular structure.
-Otherwise, the corresponding known latexmath:[{\mathbf{v}_{\mathit{known},i}}] enters the equation as:
-
-`= dependent`: no particular structure, latexmath:[{{\mathbf{f}(\ldots,\ \mathbf{v}}_{\mathit{known},i}},\ldots)]
-
-The following <<dependenciesKind>> is only allowed for floating point latexmath:[{\mathbf{v}_{\mathit{unknown}}}]:
-
-`=` <<constant>>: constant factor, latexmath:[{\mathbf{c} \cdot \mathbf{v}_{\mathit{known},i}}] where latexmath:[\mathbf{c}] is an expression that is evaluated before <<fmi3EnterInitializationMode>> is called.
-
-The following <<dependenciesKind>> is only allowed for floating point latexmath:[{\mathbf{v}_{\mathit{unknown}}}] in <<ContinuousTimeMode>> (ME), and not for <<InitialUnknown>> for <<InitializationMode>>:
-
-`=` <<fixed>>: fixed factor, latexmath:[{\mathbf{p} \cdot \mathbf{v}_{\mathit{known},i}}] where latexmath:[\mathbf{p}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called.
-
-`=` <<tunable>>: tunable factor, latexmath:[{\mathbf{p} \cdot \mathbf{v}_{\mathit{known},i}}] where latexmath:[\mathbf{p}] is an expression that is evaluated before <<fmi3ExitInitializationMode>> is called and in <<EventMode>> or at a communication point (ME and CS) due to a change of a <<tunable>> parameter.
-
-`=` <<discrete>>: discrete factor, latexmath:[{\mathbf{d} \cdot \mathbf{v}_{\mathit{known},i}}] where latexmath:[\mathbf{d}] is an expression that is evaluated before <<fmi3ExitInitializationMode>>.
-|====
-
-#### Formulation [[Formulation, `<Formulation>`]]
+==== Formulation [[Formulation, `<Formulation>`]]
 
 Each `<<Formulation>>` element within a `<<Residual>>` has the following attributes:
 
@@ -236,7 +134,7 @@ Knowns latexmath:[{\mathbf{v}_{\mathit{known}}}] in <<ContinuousTimeMode>> (ME) 
 
 * continuous states,
 
-* continous state derivatives
+* continuous state derivatives,
 
 * parameters (variables with <<causality>> = <<parameter>>),
 
@@ -249,12 +147,220 @@ If `dependencies` is present as an empty list, the formulation depends on none o
 Otherwise the formulation depends on the knowns defined by the given value references.
 
 |`dependenciesKind`
-|See the description of <<dependenciesKind>> in <<table-output-der-initialUnknown-details>>. TODO: Extend to help importer?
+|See the description of <<dependenciesKind>> in <<table-output-der-initialUnknown-details>> of the core FMI standard. TODO: Extend to help importer?
 |====
 
 ---
 
-**Example**
+=== Getting Partial Derivatives
+
+The partial derivative API functions <<fmi3GetDirectionalDerivative>> and <<fmi3GetAdjointDerivative>> are used as defined in the core FMI standard, with the following extensions for DAE FMUs:
+
+* Algebraic variables (variables listed in `<<AlgebraicVariables>>`) may appear as knowns for any unknown.
+* When the unknown is a <<Residual>> (i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
+
+==== Hello World DAE Example
+Below outlines how to map the different forms of the Hello World DAE Example to the manifest file detailed here. 
+
+===== Hello World DAE - Fully-Implicit DAE
+
+The fully-implicit representation
+
+[latexmath]
+++++
+F(\dot{x}, x, t) = 0
+++++
+
+is given by
+
+[latexmath]
+++++
+F: \mathbb{R}^3 \times \mathbb{R}^3 \times \mathbb{R} \to \mathbb{R}^3,
+\begin{pmatrix}
+x \\
+\dot{x} \\
+t
+\end{pmatrix}
+\mapsto
+\begin{pmatrix}
+F_1 \\
+F_2 \\
+F_3
+\end{pmatrix}
+=
+\begin{pmatrix}
+\dot{x_1}   - x_2   \\
+x_2 + 2 x_3 - x_1   \\
+x_2 - 3 x_3 - 2 x_1
+\end{pmatrix}
+++++
+
+Assume the FMU has these variables:
+
+[cols="1,1", options="header"]
+|====
+|Variable | valueReference
+|latexmath:[t] | 1
+|latexmath:[x_1] | 2
+|latexmath:[x_2] | 3
+|latexmath:[x_3] | 4
+|latexmath:[\dot{x_1}] | 5
+|latexmath:[\dot{x_2}] | 6
+|latexmath:[\dot{x_3}] | 7
+|latexmath:[F_1] | 8
+|latexmath:[F_2] | 9
+|latexmath:[F_3] | 10
+|====
+
+In this case `x_2` and `x_3` do not appear differentiated in any equations, hence they are classified as algebraic (element of `<<AlgebraicVariables>>`). An example of the `<<AlgebraicVariables>>` and `<<ModelStructure>>` elements would be:
+
+```xml
+<AlgebraicVariables>
+  <AlgebraicVariable valueReference="3"/> <!-- x_2 -->
+  <AlgebraicVariable valueReference="4"/> <!-- x_3 -->
+</AlgebraicVariables>
+<ModelStructure>
+  <Residual> <!-- F1 -->
+    <Formulation
+      valueReference="8"
+      dependencies="5 3"
+      dependenciesKind="fixed fixed"/>
+  </Residual>
+  <Residual> <!-- F2 -->
+    <Formulation
+      valueReference="9"
+      dependencies="2 3 4"
+      dependenciesKind="fixed fixed fixed"/>
+  </Residual>
+  <Residual> <!-- F3 -->
+    <Formulation
+      valueReference="10"
+      dependencies="2 3 4"
+      dependenciesKind="fixed fixed fixed"/>
+  </Residual>
+</ModelStructure>
+```
+NOTE: The derivatives of `x_1`, `x_2`, and `x_3` (`\dot{x_1}`, `\dot{x_2}`, `\dot{x_3}`) are still noted with the `derivative` attribute under the `ModelVariables` element, which gives the importer all the information they need to solve the equations. 
+
+===== Hello World DAE - Semi-Explicit DAE
+
+The semi-explicit representation
+
+[latexmath]
+++++
+\begin{split}
+\dot{x} & = f(x, y, t) \\
+      0 & = g(x, y, t)
+\end{split}
+++++
+
+is given by
+
+[latexmath]
+++++
+\begin{split}
+f: \mathbb{R} \times \mathbb{R}^2 \times \mathbb{R} \to \mathbb{R}, \;
+&(x,y,t) \mapsto
+\begin{pmatrix}
+y_1
+\end{pmatrix}
+ \\
+g: \mathbb{R} \times \mathbb{R}^2 \times \mathbb{R} \to \mathbb{R}, \;
+&(x,y,t) \mapsto
+\begin{pmatrix}
+y_1 + 2 y_2 - x   \\
+y_1 - 3 y_2 - 2 x
+\end{pmatrix}
+\end{split}
+++++
+
+Assume the FMU has the following variables:
+
+[cols="1,1", options="header"]
+|====
+|Variable | valueReference
+|latexmath:[t] | 1
+|latexmath:[x] | 2
+|latexmath:[y_1] | 3
+|latexmath:[y_2] | 4
+|latexmath:[\dot{x}] | 5
+|latexmath:[g_1] | 6
+|latexmath:[g_2] | 7
+|====
+
+This case contains the same algebraic variables. However this time the the derivative of `x` is given in explicit form in the `ModelStructure`:
+
+```xml
+<AlgebraicVariables>
+  <AlgebraicVariable valueReference="3"/> <!-- y1 -->
+  <AlgebraicVariable valueReference="4"/> <!-- y2 -->
+</AlgebraicVariables>
+
+<ModelStructure>
+  <ContinuousStateDerivative <!-- dot(x) = y1 -->
+    valueReference="5"
+    dependencies="3"
+    dependenciesKind="fixed"/>
+  <Residual> <!-- g1: y1 + 2*y2 - x = 0 -->
+    <Formulation
+      valueReference="6"
+      dependencies="2 3 4"
+      dependenciesKind="fixed fixed fixed"/>
+  </Residual>
+  <Residual> <!-- g2: y1 - 3*y2 - 2*x = 0 -->
+    <Formulation
+      valueReference="7"
+      dependencies="2 3 4"
+      dependenciesKind="fixed fixed fixed"/>
+  </Residual>
+</ModelStructure>
+```
+
+===== Hello World DAE - Explicit ODE
+
+This simple system could also be transformed into an explicit ODE formulation
+
+[latexmath]
+++++
+\begin{split}
+\dot{x} &= \frac{7}{5}x
+\end{split}
+++++
+
+with local variables latexmath:[y] and latexmath:[z]
+
+[latexmath]
+++++
+\begin{split}
+y       &= \frac{7}{5}x   \\
+z       &= -\frac{x}{5}
+\end{split}
+++++
+
+and exported as an ODE ModelExchange FMU:
+
+[cols="1,1", options="header"]
+|====
+|Variable | valueReference
+|latexmath:[t] | 1
+|latexmath:[x] | 2
+|latexmath:[y] | 3
+|latexmath:[z] | 4
+|latexmath:[\dot{x}] | 5
+|====
+
+This would correspond to the regular ODE ModelStructure:
+
+```xml
+<ModelStructure>
+  <ContinuousStateDerivative <!-- dot(x) = 7/5 * x -->
+    valueReference="5"
+    dependencies="2"
+    dependenciesKind="fixed"/>
+</ModelStructure>
+```
+
+==== Example 2 (differentiated formulations)
 
 Consider the following index 2 DAE system:
 
@@ -364,3 +470,4 @@ latexmath:[\dot{r}_3 = \frac{dx_1}{dt} - \frac{dx_2}{dt} = 0]
 ```
 
 The API for partial derivative, `GetDirectionalDerivative` and/or `GetAdjointDerivative` could be used with this structure to apply the dummy derivatives algorithm, or the index 2 constraint can serve as a projection constraint when integrating the index 1 formulation.
+

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -167,18 +167,18 @@ NOTE: TODO
 
 ---
 
-==== Getting Partial Derivatives
+=== Getting Partial Derivatives
 
 The partial derivative API functions https://fmi-standard.org/docs/3.0.2/#fmi3GetDirectionalDerivative[fmi3GetDirectionalDerivative] and https://fmi-standard.org/docs/3.0.2/#fmi3GetAdjointDerivative[fmi3GetAdjointDerivative] are used as defined in the core FMI standard, with the following extensions for DAE FMUs:
 
 * Algebraic variables (variables listed in `<<AlgebraicVariables>>`) may appear as knowns for any unknown.
 * When the unknown is a <<Formulation>> in a <<Residual>>(i.e., a residual variable), continuous state derivatives may additionally appear as knowns.
 
-==== Hello World DAE Example
+=== Hello World DAE Example
 
 Below outlines how to map the different forms of the Hello World DAE Example to the manifest file detailed here.
 
-===== Hello World DAE - Fully-Implicit DAE
+==== Hello World DAE - Fully-Implicit DAE
 
 The fully-implicit representation
 
@@ -259,7 +259,7 @@ An example of the `<<AlgebraicVariables>>` and `<<ModelStructure>>` elements wou
 ```
 NOTE: The derivatives of `x_1`, `x_2`, and `x_3` (`\dot{x_1}`, `\dot{x_2}`, `\dot{x_3}`) are still noted with the `derivative` attribute under the `ModelVariables` element, which gives the importer all the information they need to solve the equations.
 
-===== Hello World DAE - Semi-Explicit DAE
+==== Hello World DAE - Semi-Explicit DAE
 
 The semi-explicit representation
 
@@ -334,7 +334,7 @@ However this time the the derivative of `x` is given in explicit form in the `Mo
 </ModelStructure>
 ```
 
-===== Hello World DAE - Explicit ODE
+==== Hello World DAE - Explicit ODE
 
 This simple system could also be transformed into an explicit ODE formulation
 
@@ -378,7 +378,7 @@ This would correspond to the regular ODE ModelStructure:
 </ModelStructure>
 ```
 
-==== Example 2 (differentiated formulations)
+=== Example 2 (differentiated formulations)
 
 Consider the following index 2 DAE system:
 

--- a/docs/5____literature.adoc
+++ b/docs/5____literature.adoc
@@ -83,3 +83,6 @@
   "Simulation of Large-Scale Models in Modelica: State of the Art and Future Perspectives".
   Proceedings of the 11th International Modelica Conference, pp. 459-468, 2015.
   https://dx.doi.org/10.3384/ecp15118459
+
+* [[[PW13]]]
+  Preston-Werner, T. (2013): **Semantic Versioning 2.0.0**.  https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
## Related Issues

#39 Added a small note for partial derivatives, however a proper example is still missing

## Changes

Removed copied text from core-standard (i.e. don't redefine the ModelStructure). Instead just specify that there is an additional element `Residual`. 

Also added example of XML using the Hello World DAE example.

## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
