### PR TITLE
Update copyright year

### DIFF
--- a/docs/0____preamble.adoc
+++ b/docs/0____preamble.adoc
@@ -3,7 +3,7 @@ This layered standard on top of FMI 3.0 defines how to exchange dynamic models i
 NOTE: Although the document refers to version 3.0 of the FMI standard, everything described in this document also applies to all subsequent minor versions.
 For further information on compatibility, see section https://fmi-standard.org/docs/3.0/#VersioningLayered[Versioning and Layered Standards] in the FMI 3.0 specification.
 
-Copyright (C) 2025 The Modelica Association Project FMI.
+Copyright (C) 2025-2026 The Modelica Association Project FMI.
 
 This document is licensed under the Attribution-ShareAlike 4.0 International license.
 The code is released under the 2-Clause BSD License.


### PR DESCRIPTION
## Related Issues

The copyright doesn't contain 2026.

## Changes

* Added time span for copyright year.

## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
