### PR TITLE
Fixing section id / numbering

### DIFF
--- a/docs/2_1_1_dae_representation.adoc
+++ b/docs/2_1_1_dae_representation.adoc
@@ -2,14 +2,14 @@
 
 // Sources: https://www.fs.isy.liu.se/Edu/Courses/Simulation/OH/
 
-[dae-representation]
+[#dae-representation]
 ==== DAE representation
 
 There are different forms of DAEs.
 
 For simplicity discontinuous states are currently disregarded.
 
-[implicit-dae]
+[#implicit-dae]
 ===== Fully-Implicit DAE
 
 The generic _fully-implicit DAE_, or _implicit DAE_, formulation:
@@ -32,7 +32,7 @@ with dynamic variables latexmath:[x(t)], algebraic variables latexmath:[y(t)] an
 
 Note that latexmath:[x(t)] is not necessarily the state variable, more on this in <<Perturbation Index, section 2.1.1>>.
 
-[semi-explicit-index-1-dae]
+[#semi-explicit-index-1-dae]
 ===== Semi-Explicit Index 1 / Hessenberg index 1 DAE
 
 The _semi-explicit index 1_, also called _Hessenberg index 1_, DAE representation
@@ -49,7 +49,7 @@ with latexmath:[g] solvable for latexmath:[y], latexmath:[det \left( \frac{\part
 
 Here latexmath:[f] is called the _differential equations_ and latexmath:[g] the _algebraic equations_.
 
-[relationship-fully-implicit-semi-explicit]
+[#relationship-fully-implicit-semi-explicit]
 ===== Relationship between fully-implicit and semi-explicit DAE
 
 A fully implicit DAE
@@ -69,7 +69,7 @@ can always be rewritten as a semi-explicit DAE by introducing a new algebraic va
 \end{split}
 ++++
 
-[semi-explicit-dae]
+[#semi-explicit-dae]
 ===== Semi-Explicit DAE
 
 The _semi-explicit DAE_ representation
@@ -87,7 +87,7 @@ The _semi-explicit DAE_ representation
 
 with latexmath:[g^1] solvable for latexmath:[y], latexmath:[det \left( \frac{\partial}{\partial y}g^1\right) \neq 0] and latexmath:[\left\{ \frac{d}{dt} g_i^k \right\} \subseteq \{ g_i^{k-1}\}, \; k > 1].
 
-[mass-matrix-dae]
+[#mass-matrix-dae]
 ===== Mass matrix DAE
 
 [latexmath]
@@ -119,7 +119,7 @@ g(x(t), y(t), t)
 
 See <<cui2020mass>>.
 
-[linear-time-invariant-dae]
+[#linear-time-invariant-dae]
 ===== Linear time-invariant DAE
 
 [latexmath]

--- a/docs/2_1_2_indices.adoc
+++ b/docs/2_1_2_indices.adoc
@@ -1,12 +1,12 @@
 :stem: latexmath
 
-[indices]
+[#indices]
 ==== Indices
 
 There are multiple, sometimes closely related, definitions of indices for DAE systems.
 Usually these indices are a measure of how far from an ODE the DAE is.
 
-[differential-index]
+[#differential-index]
 ===== Differential Index
 
 The minimum number of times a DAE
@@ -20,7 +20,7 @@ has to be differentiated with respect to time latexmath:[t] to be able to determ
 
 See <<hairer2006numerical,[hairer2006numerical]>>.
 
-[perturbation-index]
+[#perturbation-index]
 ===== Perturbation Index
 
 The _perturbation index_ measures the sensitivity of the solution of a DAE to perturbations of its right-hand side.
@@ -50,7 +50,7 @@ A DAE with perturbation index greater than 1 is called a _higher-index DAE_.
 
 See <<hairer2006numerical,[hairer2006numerical]>>.
 
-[example-structural-singularity]
+[#example-structural-singularity]
 ====== Example of Structural Singularity
 
 <<cellier2006continuous,[cellier2006continuous, chapter 7.7 Structural Singularity Elimination]>> provides a simple electric circuit model that is a higher-index DAE.

--- a/docs/2_1_3_dae_example.adoc
+++ b/docs/2_1_3_dae_example.adoc
@@ -1,6 +1,6 @@
 :stem: latexmath
 
-[dae-example]
+[#dae-example]
 ==== Hello World DAE Example
 
 A simple initial-value problem

--- a/docs/2_1___mathematical_notation.adoc
+++ b/docs/2_1___mathematical_notation.adoc
@@ -1,4 +1,4 @@
-[mathematical-notation]
+[#mathematical-notation]
 === Mathematical Notation
 
 .Additional symbols for specific variable types.
@@ -10,6 +10,7 @@
 |[[algebraic,algebraic variables]]latexmath:[\mathbf{z}_c]
 |A vector of real continuous-time variables representing the continuous-time <<algebraic,algebraic variables>>.
 |====
+
 include::2_1_1_dae_representation.adoc[]
 
 include::2_1_2_indices.adoc[]


### PR DESCRIPTION
## Related Issues

The numbering for chapter 2 is broken:

<img width="687" height="712" alt="image" src="https://github.com/user-attachments/assets/33131363-2a3d-4f78-b859-e629bff15fc8" />

## Changes

* Use `[#word]` to set an ID, otherwise `[word]` is a style attribute and breaks numbering of headlines

## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
