### PR TITLE
`enableDAEModeVariable` Structural Parameter

### DIFF
--- a/docs/2_2___ode_to_dae_mode.adoc
+++ b/docs/2_2___ode_to_dae_mode.adoc
@@ -25,9 +25,9 @@ The `enableDAEModeVariable` parameter is declared in the `modelDescription.xml` 
          description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
 ----
 
-and must be referenced by name within the FMI-LS-DAE manifest file via attribute <<enableDAEModeVariable>>, see <<layered-standard-manifest-file>>.
+and must be referenced by value reference within the FMI-LS-DAE manifest file via attribute <<enableDAEModeVariable>>, see <<layered-standard-manifest-file>>.
 
-The `name` and `valueReference` is assigned freely by the FMU exporter; the importer locates the parameter by its `name` declared in attribute <<enableDAEModeVariable>> of `fmi-ls-manifest.xml`.
+The `name` and `valueReference` is assigned freely by the FMU exporter; the importer locates the parameter by its `valueReference` declared in attribute <<enableDAEModeVariable>> of `fmi-ls-manifest.xml`.
 The `description` attribute is optional.
 The `variability` must be either `tunable` or `fixed`:
 

--- a/docs/2_2___ode_to_dae_mode.adoc
+++ b/docs/2_2___ode_to_dae_mode.adoc
@@ -1,0 +1,78 @@
+[#ode-to-dae-mode]
+=== Changing between ODE and DAE Mode
+
+An FMU that implements this layered standard is simultaneously a valid ODE FMU and a DAE FMU.
+To remain backward-compatible with importers that do not support this layered standard, the FMU **defaults to ODE mode** on instantiation.
+An importer that is aware of this layered standard must explicitly switch the FMU into DAE mode before use.
+
+[#enable-dae-mode-variable]
+==== The `enableDAEModeVariable` Structural Parameter
+
+Switching between ODE and DAE behavior is controlled by a https://fmi-standard.org/docs/3.0.2/#structuralParameter[structural parameter] called `enableDAEModeVariable`.
+
+A structural parameter (`causality = structuralParameter`) may only be set during https://fmi-standard.org/docs/3.0.2/#ConfigurationMode[Configuration Mode] or https://fmi-standard.org/docs/3.0.2/#ReconfigurationMode[Reconfiguration Mode].
+This constraint ensures that the importer can re-examine the model structure from the manifest and reinitialize its solver before any computation takes place.
+
+The `enableDAEModeVariable` parameter is declared in the `modelDescription.xml` as follows:
+
+[source,xml]
+----
+<Boolean name="<free to choose>"
+         valueReference="<free to choose>"
+         causality="structuralParameter"
+         variability="tunable|fixed"
+         start="false"
+         description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
+----
+
+and must be referenced by name within the FMI-LS-DAE manifest file via attribute <<enableDAEModeVariable>>, see <<layered-standard-manifest-file>>.
+
+The `name` and `valueReference` is assigned freely by the FMU exporter; the importer locates the parameter by its `name` declared in attribute <<enableDAEModeVariable>> of `fmi-ls-manifest.xml`.
+The `description` attribute is optional.
+The `variability` must be either `tunable` or `fixed`:
+
+* `fixed` — the mode can only be set in https://fmi-standard.org/docs/3.0.2/#ConfigurationMode[Configuration Mode] (before `fmi3EnterInitializationMode`).
+  Use this when the FMU does not support switching modes at runtime.
+* `tunable` — the mode can additionally be changed in https://fmi-standard.org/docs/3.0.2/#ReconfigurationMode[Reconfiguration Mode] during simulation.
+
+The structural parameter `enableDAEModeVariable` must not be referenced in `<Dimension>` elements.
+
+.`enableDAEModeVariable` structural parameter values.
+[[table-dae-mode-parameter]]
+[cols="1,4",options="header"]
+|====
+|Value
+|Meaning
+
+|`false` (default)
+|The FMU behaves as a standard ODE Model Exchange FMU.
+All DAE-specific information in the layered standard manifest is ignored by the importer.
+
+|`true`
+|The FMU behaves as a DAE FMU.
+The importer must read the <<AlgebraicVariables>>, <<ModelStructure>>, and <<Residual>> elements from the layered standard manifest and use them to drive the simulation.
+|====
+
+==== Entering DAE Mode
+
+Because `enableDAEModeVariable` is a structural parameter, the importer must change it inside a configuration or reconfiguration scope.
+
+===== At Instantiation (Configuration Mode)
+
+The typical flow for an importer that uses the FMU in DAE mode from the start is:
+
+. Call `fmi3InstantiateModelExchange(...)` to create the FMU instance.
+. Call `fmi3EnterConfigurationMode(instance)` to enter https://fmi-standard.org/docs/3.0.2/#ConfigurationMode[Configuration Mode].
+. Call `fmi3SetBoolean(instance, {vr}, 1, {true}, 1)` to enable DAE mode, where `vr` is the `valueReference` of `enableDAEModeVariable`.
+. Call `fmi3ExitConfigurationMode(instance)` to return to the https://fmi-standard.org/docs/3.0.2/#InstantiatedState[Instantiated] state.
+. Continue with the normal FMI initialization sequence (`fmi3EnterInitializationMode`, etc.).
+
+===== During Simulation (Reconfiguration Mode)
+
+When `variability="tunable"`, an importer may also switch between ODE and DAE mode at runtime by entering https://fmi-standard.org/docs/3.0.2/#ReconfigurationMode[Reconfiguration Mode] from https://fmi-standard.org/docs/3.0.2/#EventMode[Event Mode]:
+
+. Call `fmi3EnterConfigurationMode(instance)` from Event Mode to enter Reconfiguration Mode.
+. Call `fmi3SetBoolean(instance, {vr}, 1, {newValue}, 1)` with the new mode value.
+. Call `fmi3ExitConfigurationMode(instance)` to return to Event Mode.
+
+NOTE: After switching modes, the importer is responsible for reinitializing its solver, and ensuring a consistent state before resuming the simulation.

--- a/docs/2____common_concepts.adoc
+++ b/docs/2____common_concepts.adoc
@@ -1,3 +1,5 @@
 == Common Concepts
 
 include::2_1___mathematical_notation.adoc[]
+
+include::2_2___ode_to_dae_mode.adoc[]

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -1,4 +1,5 @@
 :stem: latexmath
+
 == Layered Standard Manifest File [[layered-standard-manifest-file]]
 
 This layered standard requires the use of a layered standard manifest file and it shall be stored inside the FMU at the following path: `/extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml`.
@@ -52,6 +53,13 @@ The XML attributes of `<fmiLayeredStandardManifest>` are:
 |`\http://fmi-standard.org/fmi-ls-manifest`
 |`Layered standard for DAE support in FMI`
 |String with a brief description of the layered standard that is suitable for display to users.
+
+|`enableDAEModeVariable`
+|unqualified
+|`<free to choose>`
+|[[enableDAEModeVariable, `enableDAEModeVariable`]]
+The https://fmi-standard.org/docs/3.0.2/#table-variableBase-attributes[name] of the https://fmi-standard.org/docs/3.0.2/#structuralParameter[structural parameter] in the `modelDescription.xml` that enables DAE mode.
+See <<enable-dae-mode-variable>> for the full semantics and the calling sequences used to change the mode.
 |====
 
 === Algebraic variables [[AlgebraicVariables, `<AlgebraicVariables>`]]

--- a/examples/xml/fmi-ls-empty-example.xml
+++ b/examples/xml/fmi-ls-empty-example.xml
@@ -6,4 +6,4 @@
   fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
   fmi-ls:fmi-ls-version="0.1"
   fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
-  enableDAEModeVariable="isDAE" />
+  enableDAEModeVariable="1234" />

--- a/examples/xml/fmi-ls-empty-example.xml
+++ b/examples/xml/fmi-ls-empty-example.xml
@@ -6,4 +6,4 @@
   fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
   fmi-ls:fmi-ls-version="0.1"
   fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
-  isDaeFmu="true"/>
+  enableDAEModeVariable="isDAE" />

--- a/schema/fmi3LayeredStandardDaeManifest.xsd
+++ b/schema/fmi3LayeredStandardDaeManifest.xsd
@@ -7,7 +7,7 @@
 		schemaLocation="fmi3LayeredStandardManifest.xsd" />
 	<xs:annotation>
 		<xs:documentation>
-			Copyright(c) 2025 Modelica Association Project FMI.
+			Copyright(c) 2025 - 2026 Modelica Association Project FMI.
 			All rights reserved.
 
 			This file is licensed by the copyright holders under the 2-Clause BSD License
@@ -45,10 +45,10 @@
 			<xs:attribute ref="fmi-ls:fmi-ls-version" use="required" />
 			<xs:attribute ref="fmi-ls:fmi-ls-description" use="required"
 				fixed="Layered standard for DAE support in FMI." />
-			<xs:attribute name="enableDAEModeVariable" type="xs:normalizedString" use="required">
+			<xs:attribute name="enableDAEModeVariable" type="xs:unsignedInt" use="required">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">
-						Specify name of `enableDAEModeVariable` structural parameter in modelDescription.xml
+						Specify value reference of `enableDAEModeVariable` structural parameter in modelDescription.xml
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>

--- a/schema/fmi3LayeredStandardDaeManifest.xsd
+++ b/schema/fmi3LayeredStandardDaeManifest.xsd
@@ -45,9 +45,11 @@
 			<xs:attribute ref="fmi-ls:fmi-ls-version" use="required" />
 			<xs:attribute ref="fmi-ls:fmi-ls-description" use="required"
 				fixed="Layered standard for DAE support in FMI." />
-			<xs:attribute name="isDaeFmu" type="xs:boolean" default="false">
+			<xs:attribute name="enableDAEModeVariable" type="xs:normalizedString" use="required">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">If true, this FMU represents a DAE FMU.</xs:documentation>
+					<xs:documentation xml:lang="en">
+						Specify name of `enableDAEModeVariable` structural parameter in modelDescription.xml
+					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
 		</xs:complexType>


### PR DESCRIPTION
## Related Issues

Fixes #50.

## Changes

* Mandatory `enableDAEModeVariable` boolean structural parameter in *modelDescription.xml*:

  ```xml
  <Boolean name="<free to choose>"
           valueReference="<free to choose>"
           causality="structuralParameter"
           variability="tunable|fixed"
           start="false"
           description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
  ```
  
* Mandatory reference in FMI-LS-DAE manifest file *fmi-ls-manifest.xml*:

  ```xml
  <fmi-dae [...] enableDAEModeVariable="<free to choose>" />
  ```

* Describe how to change between ODE and DAE mode

## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
