### PR TITLE
Adding citation, sorting badges

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+cff-version: 1.2.0
+message: "If you use this layered standard, please cite it as below."
+type: software
+title: "FMI Layered Standard for DAE (FMI-LS-DAE)"
+repository-code: "https://github.com/modelica/fmi-ls-dae"
+license: BSD-2-Clause
+
+preferred-citation:
+  type: article
+  title: "Towards an FMI Layered Standard for DAE: Applications for Simulation and Optimization"
+  authors:
+    - family-names: Nahodovic
+      given-names: Elmir
+    - family-names: Heuermann
+      given-names: Andreas
+    - family-names: Andersson
+      given-names: Joel A. E.
+    - family-names: Verulkar
+      given-names: Adwait
+    - family-names: Sivaramakrishnan
+      given-names: Srikanth
+    - family-names: Najafi
+      given-names: Masoud
+    - family-names: Langenkamp
+      given-names: Linus
+    - family-names: Bertsch
+      given-names: Christian
+    - family-names: Henningsson
+      given-names: Erik
+    - family-names: Olsson
+      given-names: Hans
+    - family-names: Bachmann
+      given-names: Bernhard
+  year: 2026
+  month: 6
+  url: "https://arxiv.org/abs/2606.22544"
+  doi: "10.48550/arXiv.2606.22544"
+  notes: "Preprint"

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Code released under the [2-Clause BSD License].
 For development there is a private sandbox
 [modelica/fmi-ls-dae-sandbox][sandbox] to store non-public information.
 
-[2-Clause BSD License]: https://opensource.org/licenses/BSD-2-Clause
-[badge-build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml/badge.svg?branch=main
 [badge-docs]: https://img.shields.io/badge/Specification-FMI--LS--DAE-blue?logo=github
-[badge-validate-xml]: https://github.com/modelica/fmi-ls-dae/actions/workflows/validate-xml.yml/badge.svg?branch=main
-[build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml
-[contributing-file]: CONTRIBUTING.md
-[FMI]: https://fmi-standard.org/
-[sandbox]: https://github.com/modelica/fmi-ls-dae-sandbox
 [spec]: https://modelica.github.io/fmi-ls-dae/main/
+[badge-build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml/badge.svg?branch=main
+[build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml
+[badge-validate-xml]: https://github.com/modelica/fmi-ls-dae/actions/workflows/validate-xml.yml/badge.svg?branch=main
 [validate-xml]: https://github.com/modelica/fmi-ls-dae/actions/workflows/validate-xml.yml
+[FMI]: https://fmi-standard.org/
+[contributing-file]: CONTRIBUTING.md
+[2-Clause BSD License]: https://opensource.org/licenses/BSD-2-Clause
+[sandbox]: https://github.com/modelica/fmi-ls-dae-sandbox

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FMI Layered Standard for DAE (FMI-LS-DAE)
 
+[![FMI-LS-DAE Specification][badge-docs]][spec]
 [![Build Layered Standard DAE][badge-build-ls-dae]][build-ls-dae]
 [![Validate XML manifests][badge-validate-xml]][validate-xml]
-[![Static Badge][badge-docs]][spec]
 
 This repository contains an early prototype draft for the FMI Layered Standard
 for DAE (FMI-LS-DAE) based on the [Function Mock-up Interface][FMI] (FMI).
@@ -13,13 +13,19 @@ ModelExchange.
 
 ## FMI-LS-DAE Standard
 
-This [FMI 3.0 Layered Standard][spec] for DAE export is currently maintained on
-[GitHub][githubspec] and is published here.
+This [FMI 3.0 Layered Standard][spec] for DAE export is currently maintained in this repository and published at [modelica.github.io/fmi-ls-dae/main][spec].
 
 ## Repository Structure
 
 * `docs` -- Sources of the specification document
 * `schema` -- XSD schema for this FMI Layered Standard
+
+## Citation
+
+If you use this work, please cite the accompanying pre-print:
+
+> Nahodovic et al., "Towards an FMI Layered Standard for DAE: Applications for Simulation and Optimization", arXiv:2606.22544, 2026.
+> <https://doi.org/10.48550/arXiv.2606.22544>
 
 ## How to Contribute
 
@@ -37,12 +43,11 @@ For development there is a private sandbox
 
 [2-Clause BSD License]: https://opensource.org/licenses/BSD-2-Clause
 [badge-build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml/badge.svg?branch=main
-[badge-docs]: https://img.shields.io/badge/docs-FMI--LS--DAE-blue?logo=github
+[badge-docs]: https://img.shields.io/badge/Specification-FMI--LS--DAE-blue?logo=github
 [badge-validate-xml]: https://github.com/modelica/fmi-ls-dae/actions/workflows/validate-xml.yml/badge.svg?branch=main
 [build-ls-dae]: https://github.com/modelica/fmi-ls-dae/actions/workflows/build-ls-dae.yml
 [contributing-file]: CONTRIBUTING.md
 [FMI]: https://fmi-standard.org/
-[githubspec]: docs/index.adoc
 [sandbox]: https://github.com/modelica/fmi-ls-dae-sandbox
 [spec]: https://modelica.github.io/fmi-ls-dae/main/
 [validate-xml]: https://github.com/modelica/fmi-ls-dae/actions/workflows/validate-xml.yml


### PR DESCRIPTION
## Related Issues

We have a pre-print for FMI-LS-DAE at https://arxiv.org/abs/2606.22544. We should ask people to cite it if they happen to use FMI-LS-DAE and write a paper about it.

## Changes

- Adding Citation.cff. It will generate the following bib tex
  ```bib
  @article{Nahodovic_Towards_an_FMI_2026,
  author = {Nahodovic, Elmir and Heuermann, Andreas and Andersson, Joel A. E. and Verulkar, Adwait and Sivaramakrishnan, Srikanth and Najafi, Masoud and Langenkamp, Linus and Bertsch, Christian and Henningsson, Erik and Olsson, Hans and Bachmann, Bernhard},
  doi = {10.48550/arXiv.2606.22544},
  month = jun,
  note = {Preprint},
  title = {{Towards an FMI Layered Standard for DAE: Applications for Simulation and Optimization}},
  url = {https://arxiv.org/abs/2606.22544},
  year = {2026}
  }
  ```
- Updating README to make it simpler to find link to specification.
  
  <img width="1315" height="562" alt="grafik" src="https://github.com/user-attachments/assets/46a8ef46-595f-4b52-a956-58b157c07954" />


## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
