### PR TITLE
Add EnableDAE element, move alg. varaibles and model structure to manifest XML

### DIFF
--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -36,8 +36,5 @@ jobs:
       - name: Validate FMI-LS-DAE XSD manifest (well-formed)
         run: xmllint --noout schema/fmi3LayeredStandardDaeManifest.xsd
 
-      - name: Validate fmi-ls-manifest.xml files
-        run: find . -name "fmi-ls-manifest.xml" | xargs xmllint --noout --schema schema/fmi3LayeredStandardDaeManifest.xsd
-
-      - name: Validate modelDescription.xml files
-        run: find reference-FMUs -name "modelDescription.xml" | xargs xmllint --noout --schema fmi3-schema/fmi3ModelDescription.xsd
+      - name: Validate example XML files
+        run: find examples -name "*.xml" | xargs xmllint --noout --schema schema/fmi3LayeredStandardDaeManifest.xsd

--- a/.github/workflows/validate-xml.yml
+++ b/.github/workflows/validate-xml.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - 'examples/**/*.xml'
+      - 'reference-FMUs/**/*.xml'
       - 'schema/**'
   pull_request:
     paths:
       - 'examples/**/*.xml'
+      - 'reference-FMUs/**/*.xml'
       - 'schema/**'
 
 jobs:
@@ -18,14 +20,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Validate XSD manifest
-        uses: phpcsstandards/xmllint-validate@v2
-        with:
-          pattern: schema/fmi3LayeredStandardDaeManifest.xsd
-          xsd-url: https://www.w3.org/2012/04/XMLSchema.xsd
+      - name: Install xmllint
+        run: sudo apt-get install -y --no-install-recommends libxml2-utils
 
-      - name: Validate XML examples
-        uses: phpcsstandards/xmllint-validate@v2
-        with:
-          pattern: 'examples/**/*.xml'
-          xsd-file: 'schema/fmi3LayeredStandardDaeManifest.xsd'
+      - name: Download FMI 3.0 schemas
+        run: |
+          mkdir fmi3-schema
+          for f in fmi3Annotation fmi3AttributeGroups fmi3BuildDescription fmi3InterfaceType \
+                   fmi3LayeredStandardManifest fmi3ModelDescription fmi3Terminal \
+                   fmi3TerminalsAndIcons fmi3Type fmi3Unit fmi3Variable fmi3VariableDependency; do
+            curl -sSfL "https://raw.githubusercontent.com/modelica/fmi-standard/v3.0.2/schema/${f}.xsd" \
+              -o "fmi3-schema/${f}.xsd"
+          done
+
+      - name: Validate FMI-LS-DAE XSD manifest (well-formed)
+        run: xmllint --noout schema/fmi3LayeredStandardDaeManifest.xsd
+
+      - name: Validate fmi-ls-manifest.xml files
+        run: find . -name "fmi-ls-manifest.xml" | xargs xmllint --noout --schema schema/fmi3LayeredStandardDaeManifest.xsd
+
+      - name: Validate modelDescription.xml files
+        run: find reference-FMUs -name "modelDescription.xml" | xargs xmllint --noout --schema fmi3-schema/fmi3ModelDescription.xsd

--- a/docs/2_2___ode_to_dae_mode.adoc
+++ b/docs/2_2___ode_to_dae_mode.adoc
@@ -25,9 +25,9 @@ The `enableDAEModeVariable` parameter is declared in the `modelDescription.xml` 
          description="Set to true to enable DAE mode as defined by FMI-LS-DAE."/>
 ----
 
-and must be referenced by value reference within the FMI-LS-DAE manifest file via attribute <<enableDAEModeVariable>>, see <<layered-standard-manifest-file>>.
+and must be referenced by value reference within the FMI-LS-DAE manifest file via the <<EnableDAE>> element, see <<layered-standard-manifest-file>>.
 
-The `name` and `valueReference` is assigned freely by the FMU exporter; the importer locates the parameter by its `valueReference` declared in attribute <<enableDAEModeVariable>> of `fmi-ls-manifest.xml`.
+The `name` and `valueReference` is assigned freely by the FMU exporter; the importer locates the parameter by its `valueReference` declared in the <<EnableDAE>> element of `fmi-ls-manifest.xml`.
 The `description` attribute is optional.
 The `variability` must be either `tunable` or `fixed`:
 

--- a/docs/4___layeredManifest.adoc
+++ b/docs/4___layeredManifest.adoc
@@ -4,16 +4,19 @@
 
 This layered standard requires the use of a layered standard manifest file and it shall be stored inside the FMU at the following path: `/extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml`.
 
-[Add figure here] shows the root element `fmiLayeredStandardManifest`.
+[Add figure here] shows the root element `fmi-ls-dae`.
 
-Two additional elements - <<AlgebraicVariables>> and <<ModelStructure>> - are included in the layered standard manifest file to describe the DAE formulation.
+Three additional elements - <<EnableDAE>>, <<AlgebraicVariables>>, and <<ModelStructure>> - are included as direct children of the root element in the layered standard manifest file to describe the DAE formulation.
 
-.`fmiModelDescription` element details.
+.`fmi-ls-dae` child elements.
 [[table-schema-fmiModelDescription]]
 [cols="1,3",options="header"]
 |====
 |Element
 |Description
+
+|<<EnableDAE>>
+|Required element referencing the https://fmi-standard.org/docs/3.0.2/#structuralParameter[structural parameter] in `modelDescription.xml` that enables DAE mode.
 
 |<<AlgebraicVariables>>
 |List of all <<AlgebraicVariable, algebraic variables>> exposed for the DAE formulation.
@@ -28,9 +31,9 @@ The <<AlgebraicVariables,algebraic variables>> can now also be included as depen
 
 |====
 
-The XML attributes of `<fmiLayeredStandardManifest>` are:
+The XML attributes of `<fmi-ls-dae>` are:
 
-.`<fmiLayeredStandardManifest>`` attribute details.
+.`<fmi-ls-dae>` attribute details.
 [[table-schema-fmi-ls-dae-attributes]]
 [cols="1,1,1,2",options="header"]
 |====
@@ -46,20 +49,31 @@ The XML attributes of `<fmiLayeredStandardManifest>` are:
 
 |`fmi-ls-version`
 |`\http://fmi-standard.org/fmi-ls-manifest`
-|`0.0.1`
+|`0.1.0`
 |Version of the layered standard. This layered standard uses semantic versioning, as defined in <<PW13>>.
 
 |`fmi-ls-description`
 |`\http://fmi-standard.org/fmi-ls-manifest`
-|`Layered standard for DAE support in FMI`
+|`Layered standard for DAE support in FMI.`
 |String with a brief description of the layered standard that is suitable for display to users.
 
-|`enableDAEModeVariable`
-|unqualified
-|`<free to choose>`
-|[[enableDAEModeVariable, `enableDAEModeVariable`]]
-The https://fmi-standard.org/docs/3.0.2/#table-variableBase-attributes[name] of the https://fmi-standard.org/docs/3.0.2/#structuralParameter[structural parameter] in the `modelDescription.xml` that enables DAE mode.
+|====
+
+=== Enabling DAE mode [[EnableDAE, `<EnableDAE>`]]
+
+The element <<EnableDAE>> references the https://fmi-standard.org/docs/3.0.2/#structuralParameter[structural parameter] in the `modelDescription.xml` that enables DAE mode.
 See <<enable-dae-mode-variable>> for the full semantics and the calling sequences used to change the mode.
+
+.Attributes to <<EnableDAE>> element.
+[[table-enable-dae-details]]
+[cols="1,5a", options="header"]
+|====
+|Attribute
+|Description
+
+|`valueReference`
+|[[enableDAEModeVariable, `valueReference`]]
+The https://fmi-standard.org/docs/3.0.2/#table-variableBase-attributes[value reference] of the structural parameter present in the `ModelVariables` of the `modelDescription.xml` that enables DAE mode.
 |====
 
 === Algebraic variables [[AlgebraicVariables, `<AlgebraicVariables>`]]

--- a/examples/xml/fmi-ls-dae-empty-example.xml
+++ b/examples/xml/fmi-ls-dae-empty-example.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmi-ls-dae
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://fmi-standard.org/fmi-ls-manifest ../../schema/fmi3LayeredStandardDaeManifest.xsd"
+  xmlns="http://fmi-standard.org/fmi-ls-manifest"
+  xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+  fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
+  fmi-ls:fmi-ls-version="0.1"
+  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
+>
+  <EnableDAE valueReference="20" />
+
+  <AlgebraicVariables>
+    <AlgebraicVariable valueReference="5" /> <!-- z1 -->
+  </AlgebraicVariables>
+
+  <ModelStructure>
+    <!-- der(x1) = f(x1, z1, z2, u1)
+         DAE-mode deps: x1(vr=1), z1(vr=5), z2(vr=6), u1(vr=7) -->
+    <ContinuousStateDerivative
+      valueReference="2"
+      dependencies="1 5 6 7"
+      dependenciesKind="dependent dependent dependent dependent" />
+
+    <!-- __residual0 = g(x1, z1, u1, u2)
+         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
+    <Residual>
+      <Formulation
+        valueReference="11"
+        dependencies="1 5 7 8"
+        dependenciesKind="dependent dependent dependent dependent" />
+    </Residual>
+
+    <!-- y1 = h(x1, z1, u1, u2)
+         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
+    <Output
+      valueReference="9"
+      dependencies="1 5 7 8"
+      dependenciesKind="dependent dependent dependent dependent" />
+  </ModelStructure>
+
+</fmi-ls-dae>

--- a/examples/xml/fmi-ls-dae-empty-example.xml
+++ b/examples/xml/fmi-ls-dae-empty-example.xml
@@ -6,37 +6,8 @@
   xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
   fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
   fmi-ls:fmi-ls-version="0.1"
-  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
->
-  <EnableDAE valueReference="20" />
+  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI.">
 
-  <AlgebraicVariables>
-    <AlgebraicVariable valueReference="5" /> <!-- z1 -->
-  </AlgebraicVariables>
-
-  <ModelStructure>
-    <!-- der(x1) = f(x1, z1, z2, u1)
-         DAE-mode deps: x1(vr=1), z1(vr=5), z2(vr=6), u1(vr=7) -->
-    <ContinuousStateDerivative
-      valueReference="2"
-      dependencies="1 5 6 7"
-      dependenciesKind="dependent dependent dependent dependent" />
-
-    <!-- __residual0 = g(x1, z1, u1, u2)
-         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
-    <Residual>
-      <Formulation
-        valueReference="11"
-        dependencies="1 5 7 8"
-        dependenciesKind="dependent dependent dependent dependent" />
-    </Residual>
-
-    <!-- y1 = h(x1, z1, u1, u2)
-         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
-    <Output
-      valueReference="9"
-      dependencies="1 5 7 8"
-      dependenciesKind="dependent dependent dependent dependent" />
-  </ModelStructure>
+  <EnableDAE valueReference ="123"/>
 
 </fmi-ls-dae>

--- a/examples/xml/fmi-ls-dae-example.xml
+++ b/examples/xml/fmi-ls-dae-example.xml
@@ -6,8 +6,37 @@
   xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
   fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
   fmi-ls:fmi-ls-version="0.1"
-  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI.">
+  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
+>
+  <EnableDAE valueReference="20" />
 
-  <EnableDAE valueReference ="123"/>
+  <AlgebraicVariables>
+    <AlgebraicVariable valueReference="5" /> <!-- z1 -->
+  </AlgebraicVariables>
+
+  <ModelStructure>
+    <!-- der(x1) = f(x1, z1, z2, u1)
+         DAE-mode deps: x1(vr=1), z1(vr=5), z2(vr=6), u1(vr=7) -->
+    <ContinuousStateDerivative
+      valueReference="2"
+      dependencies="1 5 6 7"
+      dependenciesKind="dependent dependent dependent dependent" />
+
+    <!-- __residual0 = g(x1, z1, u1, u2)
+         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
+    <Residual>
+      <Formulation
+        valueReference="11"
+        dependencies="1 5 7 8"
+        dependenciesKind="dependent dependent dependent dependent" />
+    </Residual>
+
+    <!-- y1 = h(x1, z1, u1, u2)
+         DAE-mode deps: x1(vr=1), z1(vr=5), u1(vr=7), u2(vr=8) -->
+    <Output
+      valueReference="9"
+      dependencies="1 5 7 8"
+      dependenciesKind="dependent dependent dependent dependent" />
+  </ModelStructure>
 
 </fmi-ls-dae>

--- a/examples/xml/fmi-ls-dae-example.xml
+++ b/examples/xml/fmi-ls-dae-example.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmi-ls-dae
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://fmi-standard.org/fmi-ls-manifest ../../schema/fmi3LayeredStandardDaeManifest.xsd"
+  xmlns="http://fmi-standard.org/fmi-ls-manifest"
+  xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+  fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
+  fmi-ls:fmi-ls-version="0.1"
+  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI.">
+
+  <EnableDAE valueReference ="123"/>
+
+</fmi-ls-dae>

--- a/examples/xml/fmi-ls-empty-example.xml
+++ b/examples/xml/fmi-ls-empty-example.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<fmi-dae
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="../../schema/fmi3LayeredStandardDaeManifest.xsd"
-  xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
-  fmi-ls:fmi-ls-name="org.fmi-standard.fmi-ls-dae"
-  fmi-ls:fmi-ls-version="0.1"
-  fmi-ls:fmi-ls-description="Layered standard for DAE support in FMI."
-  enableDAEModeVariable="1234" />

--- a/schema/fmi3LayeredStandardDaeManifest.xsd
+++ b/schema/fmi3LayeredStandardDaeManifest.xsd
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+	targetNamespace="http://fmi-standard.org/fmi-ls-manifest"
 	elementFormDefault="qualified"
-	attributeFormDefault="qualified">
-	<xs:import namespace="http://fmi-standard.org/fmi-ls-manifest"
-		schemaLocation="fmi3LayeredStandardManifest.xsd" />
+	attributeFormDefault="unqualified">
 	<xs:annotation>
 		<xs:documentation>
 			Copyright(c) 2025 - 2026 Modelica Association Project FMI.
@@ -39,19 +38,164 @@
 		</xs:documentation>
 	</xs:annotation>
 
-	<xs:element name="fmi-dae">
+	<!-- Declares the fmi-ls-name / fmi-ls-version / fmi-ls-description attributes
+	     referenced below. Same targetNamespace, hence include rather than import. -->
+	<xs:include schemaLocation="fmi3LayeredStandardManifest.xsd"/>
+
+	<!--
+		Root element of the FMI-LS-DAE manifest file. This layered standard provides
+		its own root element, so the generic fmiLayeredStandardManifest of the core
+		standard is not used.
+	-->
+	<xs:element name="fmi-ls-dae">
 		<xs:complexType>
-			<xs:attribute ref="fmi-ls:fmi-ls-name" use="required" fixed="org.fmi-standard.fmi-ls-dae" />
-			<xs:attribute ref="fmi-ls:fmi-ls-version" use="required" />
+			<xs:sequence>
+				<xs:element name="EnableDAE" type="fmi-ls:TEnableDAE" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
+							References the structural parameter in the modelDescription.xml
+							that enables DAE mode.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="AlgebraicVariables" type="fmi-ls:TAlgebraicVariables"
+					minOccurs="0">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
+							List of algebraic variables exposed by this DAE FMU.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ModelStructure" type="fmi-ls:TDaeModelStructure"
+					minOccurs="0">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
+							Overrides the ModelStructure in modelDescription.xml with
+							DAE-aware dependency information and residual declarations.
+						</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute ref="fmi-ls:fmi-ls-name" use="required"
+				fixed="org.fmi-standard.fmi-ls-dae"/>
+			<xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
 			<xs:attribute ref="fmi-ls:fmi-ls-description" use="required"
-				fixed="Layered standard for DAE support in FMI." />
-			<xs:attribute name="enableDAEModeVariable" type="xs:unsignedInt" use="required">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						Specify value reference of `enableDAEModeVariable` structural parameter in modelDescription.xml
-					</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
+				fixed="Layered standard for DAE support in FMI."/>
 		</xs:complexType>
 	</xs:element>
+
+	<!-- Space-separated list of value references -->
+	<xs:simpleType name="TValueReferenceList">
+		<xs:list itemType="xs:unsignedInt"/>
+	</xs:simpleType>
+
+	<!-- Single algebraic variable declaration -->
+	<xs:complexType name="TAlgebraicVariable">
+		<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Value reference of the algebraic variable in ModelVariables of
+					the modelDescription.xml.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
+	<!-- Reference to the structural parameter that enables DAE mode -->
+	<xs:complexType name="TEnableDAE">
+		<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Value reference of the structural parameter in ModelVariables of
+					the modelDescription.xml that enables DAE mode. The referenced
+					variable must be a Boolean with causality="structuralParameter"
+					and variability="tunable" or "fixed".
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
+	<!-- Container listing all algebraic variables -->
+	<xs:complexType name="TAlgebraicVariables">
+		<xs:sequence>
+			<xs:element name="AlgebraicVariable" type="fmi-ls:TAlgebraicVariable"
+				maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!-- One formulation (equation) within a Residual -->
+	<xs:complexType name="TFormulation">
+		<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Value reference of the residual variable in ModelVariables of
+					the modelDescription.xml.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="index" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Optional DAE index: number of times this equation must be
+					differentiated to obtain an index-1 system.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="dependencies" type="fmi-ls:TValueReferenceList">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Space-separated list of value references this formulation depends on.
+					If absent, dependence on all knowns is assumed.
+					If present but empty, the formulation depends on no knowns.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="dependenciesKind" type="xs:string">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Space-separated list of dependency kinds, one per entry in
+					'dependencies'. See dependenciesKind in the core FMI standard.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
+	<!-- Residual equation: one or more formulations (differentiated forms of the same constraint) -->
+	<xs:complexType name="TResidual">
+		<xs:sequence>
+			<xs:element name="Formulation" type="fmi-ls:TFormulation"
+				maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						Multiple Formulation elements within one Residual represent
+						the same constraint differentiated to successive orders.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!-- Structure element shared by Output, ContinuousStateDerivative, etc. -->
+	<xs:complexType name="TModelStructureElement">
+		<xs:attribute name="valueReference"   type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="dependencies"     type="fmi-ls:TValueReferenceList"/>
+		<xs:attribute name="dependenciesKind" type="xs:string"/>
+	</xs:complexType>
+
+	<!--
+		DAE model structure.  Overrides the ModelStructure in modelDescription.xml
+		when present.  All standard elements retain their core FMI semantics;
+		algebraic variables may additionally appear as dependencies.
+		The Residual element is new.
+	-->
+	<xs:complexType name="TDaeModelStructure">
+		<xs:choice minOccurs="0" maxOccurs="unbounded">
+			<xs:element name="Output"                    type="fmi-ls:TModelStructureElement"/>
+			<xs:element name="ContinuousStateDerivative" type="fmi-ls:TModelStructureElement"/>
+			<xs:element name="ClockedState"              type="fmi-ls:TModelStructureElement"/>
+			<xs:element name="InitialUnknown"            type="fmi-ls:TModelStructureElement"/>
+			<xs:element name="EventIndicator"            type="fmi-ls:TModelStructureElement"/>
+			<xs:element name="Residual"                  type="fmi-ls:TResidual"/>
+		</xs:choice>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/modelica/fmi-ls-dae/issues/54.

## Changes

* The structural parameter that enables DAE mode is now referenced by value reference through a dedicated `<EnableDAE valueReference="..."/>` child element instead of a name-valued attribute on the root <fmi-ls-dae> element.
* Adding XML example with `<AlgebraicVariables>` and `<ModelStructure>` elements
* Update XML validation CI

## Checklist

- [x] My employer has signed the [Corporate Contributor License Agreement][CCLA] or the [Modelica Association CLA][MA-CLA]

[CCLA]: https://github.com/modelica/fmi-standard.org/blob/main/static/assets/FMI_CCLA_v1.0_2016_06_21.pdf
[MA-CLA]: https://github.com/modelica/ModelicaAssociationCLA/releases/download/1.1.1/ModelicaAssociationCLA_1.1.1.pdf
